### PR TITLE
issue/74 Fix Inplace, Naming, and Reference Issues in Tests

### DIFF
--- a/test/infiniop/libinfiniop/utils.py
+++ b/test/infiniop/libinfiniop/utils.py
@@ -201,7 +201,7 @@ def debug(actual, desired, atol=0, rtol=1e-2, equal_nan=False, verbose=True):
 
     print_discrepancy(actual, desired, atol, rtol, verbose)
     np.testing.assert_allclose(
-        actual.cpu(), desired.cpu(), rtol, atol, equal_nan, verbose=True, strict=True
+        actual.cpu(), desired.cpu(), rtol, atol, equal_nan, verbose=True
     )
 
 

--- a/test/infiniop/rearrange.py
+++ b/test/infiniop/rearrange.py
@@ -1,6 +1,6 @@
 import torch
 import ctypes
-from ctypes import POINTER, Structure, c_int32, c_size_t, c_uint64, c_void_p, c_float
+from ctypes import POINTER, Structure, c_int32, c_void_p
 from libinfiniop import (
     infiniopHandle_t,
     infiniopTensorDescriptor_t,
@@ -9,7 +9,7 @@ from libinfiniop import (
     get_test_devices,
     check_error,
     rearrange_if_needed,
-    create_workspace,
+    rearrange_tensor,
     test_operator,
     get_args,
     debug,
@@ -62,14 +62,14 @@ def test(
     x_stride,
     y_shape,
     y_stride,
-    x_dtype=torch.float16,
+    dtype=torch.float16,
 ):
     print(
-        f"Testing Rerrange on {torch_device} with x_shape:{x_shape} x_stride:{x_stride} y_shape:{y_shape} y_stride:{y_stride} x_dtype:{x_dtype}"
+        f"Testing Rerrange on {torch_device} with x_shape:{x_shape} x_stride:{x_stride} y_shape:{y_shape} y_stride:{y_stride} dtype:{dtype}"
     )
 
-    x = torch.rand(x_shape, dtype=x_dtype).to(torch_device)
-    y = torch.zeros(y_shape, dtype=x_dtype).to(torch_device)
+    x = torch.rand(x_shape, dtype=dtype).to(torch_device)
+    y = torch.zeros(y_shape, dtype=dtype).to(torch_device)
 
     x, y = [
         rearrange_if_needed(tensor, stride)

--- a/test/infiniop/rms_norm.py
+++ b/test/infiniop/rms_norm.py
@@ -2,7 +2,7 @@ from ctypes import POINTER, Structure, c_int32, c_uint64, c_void_p, c_float
 import ctypes
 import torch
 import ctypes
-from ctypes import POINTER, Structure, c_int32, c_size_t, c_uint64, c_void_p, c_float
+from ctypes import POINTER, Structure, c_int32, c_uint64, c_void_p, c_float
 from libinfiniop import (
     infiniopHandle_t,
     infiniopTensorDescriptor_t,
@@ -69,12 +69,12 @@ def test(
     w_shape,
     y_stride,
     x_stride,
-    dtype=torch.float16,
     w_dtype=torch.float16,
+    dtype=torch.float16,
 ):
     print(
         f"Testing RMS_Norm on {torch_device} with y_shape:{y_shape} x_shape:{x_shape} w_shape:{w_shape}"
-        f" dtype:{dtype} w_dtype:{w_dtype}"
+        f" y_stride:{y_stride} x_stride:{x_stride} w_dtype:{w_dtype} dtype:{dtype}"
     )
 
     y = torch.zeros(y_shape, dtype=dtype).to(torch_device)

--- a/test/infiniop/rotary_embedding.py
+++ b/test/infiniop/rotary_embedding.py
@@ -2,6 +2,7 @@ import torch
 import ctypes
 from ctypes import POINTER, Structure, c_int32, c_size_t, c_uint64, c_void_p, c_float
 from libinfiniop import (
+    InfiniDtype,
     infiniopHandle_t,
     infiniopTensorDescriptor_t,
     open_lib,
@@ -131,7 +132,7 @@ def test(lib, handle, torch_device, shape, strides=None, dtype=torch.float16):
     check_error(
         lib.infiniopCreateRoPEDescriptor(
             handle,
-            byref(descriptor),
+            ctypes.byref(descriptor),
             t_tensor.descriptor,
             pos_tensor.descriptor,
             sin_table_tensor.descriptor,
@@ -231,4 +232,5 @@ if __name__ == "__main__":
     # Execute tests
     for device in get_test_devices(args):
         test_operator(lib, device, test, _TEST_CASES, _TENSOR_DTYPES)
+        
     print("\033[92mTest passed!\033[0m")


### PR DESCRIPTION
- Fix Swiglu inplace issue addressed by Issue #74 
- Temporarily comment out 3D test cases in Swiglu tests since they are not currently supported
- Fix several naming inconsistency in tests
- Remove some unused import statements and add some missing import statements
- Add the missing arguments in print statements for some tests